### PR TITLE
Correctly ignore sloped paths

### DIFF
--- a/src/add.js
+++ b/src/add.js
@@ -3,7 +3,7 @@ function buildOnTile(surface, path) {
     surface.hasOwnership &&
     path &&
     !path.isQueue &&
-    !path.slopeDirection
+    path.slopeDirection === null;
 }
 
 export default function Add(bench=null, bin=null) {


### PR DESCRIPTION
This fixes #4. `slopeDirection` of `0` previously wasn't ignored.