### PR TITLE
Build Benches & Bins On All Levels of Footpath

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: Build
 on:
   push:
-    branches: [master]
+    tags_ignore:
+      - v*
 jobs:
   build:
     name: Ensure Build Succeeds

--- a/src/add.js
+++ b/src/add.js
@@ -1,9 +1,7 @@
 function buildOnTile(surface, path) {
-  return surface &&
-    surface.hasOwnership &&
-    path &&
-    !path.isQueue &&
-    path.slopeDirection === null;
+  return surface?.hasOwnership &&
+    !path?.isQueue &&
+    path?.slopeDirection === null
 }
 
 export default function Add(bench=null, bin=null) {
@@ -14,11 +12,13 @@ export default function Add(bench=null, bin=null) {
     for (let x = 0; x < map.size.x; x++) {
       const { elements } = map.getTile(x, y)
       const surface = elements.filter(element => element.type === "surface")[0]
-      const path = elements.filter(element => element.type === "footpath")[0]
+      const footpaths = elements.filter(element => element.type === "footpath")
 
-      if (buildOnTile(surface, path)) {
-        paths.push({ path: path, x: x, y: y })
-      }
+      footpaths.forEach(path => {
+        if (buildOnTile(surface, path)) {
+          paths.push({ path: path, x: x, y: y })
+        }
+      })
     }
   }
 


### PR DESCRIPTION
Originally, benches and bins were only getting placed on the lowest
level of footpath, and ignoring multiple levels of path. This change
fixes that issue, and allows benches/bins to be placed on all levels of
footpath for a given tile.

Fixes #9