### PR TITLE
Build Bins on Sloped Footpaths

### DIFF
--- a/src/add.js
+++ b/src/add.js
@@ -1,11 +1,5 @@
-function buildOnTile(surface, path) {
-  return surface?.hasOwnership &&
-    !path?.isQueue &&
-    path?.slopeDirection === null
-}
-
-export default function Add(bench=null, bin=null) {
-  const paths = []
+export default function Add(bench, bin, buildBinsOnAllSlopedPaths) {
+  const paths = { unsloped: [], sloped: [] }
 
   // Iterate every tile in the map
   for (let y = 0; y < map.size.y; y++) {
@@ -15,22 +9,33 @@ export default function Add(bench=null, bin=null) {
       const footpaths = elements.filter(element => element.type === "footpath")
 
       footpaths.forEach(path => {
-        if (buildOnTile(surface, path)) {
-          paths.push({ path: path, x: x, y: y })
+        if (surface?.hasOwnership && !path?.isQueue) {
+          if (path?.slopeDirection === null) {
+            paths.unsloped.push({ path, x, y })
+          } else {
+            paths.sloped.push({ path, x, y })
+          }
         }
       })
     }
   }
 
-  if (bench !== null && bin !== null) {
-    paths.forEach((path, index) => {
-      if (path.x % 2 === path.y % 2) {
-        path.path.addition = bench
-        park.cash -= 5
-      } else {
-        path.path.addition = bin
-        park.cash -= 3
-      }
-    })
-  }
+  // Build benches and bins on unsloped paths
+  paths.unsloped.forEach(({ path, x, y }) => {
+    if (x % 2 === y % 2) {
+      path.addition = bench
+      park.cash -= 5
+    } else {
+      path.addition = bin
+      park.cash -= 3
+    }
+  })
+
+  // Build bins on sloped paths
+  paths.sloped.forEach(({ path, x, y }) => {
+    if (buildBinsOnAllSlopedPaths || (x % 2 === y % 2)) {
+      path.addition = bin
+      park.cash -= 3
+    }
+  })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ function main() {
 
     let bench = benches.length > 0 ? benches[0].index : 0
     let bin = bins.length > 0 ? bins[0].index : 0
+    let buildBinsOnAllSlopedPaths = false
 
     const window = ui.openWindow({
       title: name,
@@ -60,14 +61,26 @@ function main() {
           onChange: (number) => { bin = bins[number].index }
         },
         {
+          type: "checkbox",
+          x: 10,
+          y: 55,
+          width: 200,
+          height: 15,
+          isChecked: buildBinsOnAllSlopedPaths,
+          text: "Build bins on all sloped footpaths",
+          onChange: (checked) => { buildBinsOnAllSlopedPaths = checked }
+        },
+        {
           type: "button",
           text: "Add",
           x: 10,
-          y: 70,
+          y: 75,
           width: 50,
           height: 20,
           onClick: () => {
-            Add(bench, bin)
+            if (bench !== null && bin !== null) {
+              Add(bench, bin, buildBinsOnAllSlopedPaths)
+            }
             window.close()
           }
         }


### PR DESCRIPTION
Previously, sloped footpaths were entirely ignored by the plugin just to
get it out there and usable. But the desire to build on sloped footpaths
with Benchwarmer has always existed, at least in my mind. @RundesBalli
also felt like this needed changing, and shoutouts to them for
suggesting this change.

Now, sloped footpaths will get alternating bins just like every other
path by default. However, there's a new checkbox option to just build bins on
every sloped footpath. I've used this strategy myself and it greatly
helps achieve and sustain a high park value in scenarios that have a lot of
sloped footpaths, but one might want to use that extra space on
footpaths for other stuff (like scenery). At any rate, the option is
there if you need it, and sloped footpaths will no longer be exempted
from building.

Fixes #10