### PR TITLE
Build benches and bins on paths with construction rights

### DIFF
--- a/src/add.js
+++ b/src/add.js
@@ -9,7 +9,7 @@ export default function Add(bench, bin, buildBinsOnAllSlopedPaths) {
       const footpaths = elements.filter(element => element.type === "footpath")
 
       footpaths.forEach(path => {
-        if (surface?.hasOwnership && !path?.isQueue) {
+        if ((surface?.hasOwnership || surface?.hasConstructionRights) && !path?.isQueue) {
           if (path?.slopeDirection === null) {
             paths.unsloped.push({ path, x, y })
           } else {


### PR DESCRIPTION
In scenarios such as Big Pier where the entire park is built in a zone
with just construction rights but no ownership, benches and bins were
not being built on the respective paths.