### PR TITLE
Fix handling of other additions and add toggle to disable

### DIFF
--- a/src/add.js
+++ b/src/add.js
@@ -6,10 +6,11 @@ const PRICE_BENCH = 50
 
 export default function Add(settings) {
   const paths = { unsloped: [], sloped: [] }
-  const isBenchOrBin = ({ path }) => (
-    path.addition === null ||
-    settings.benches.includes(path.addition) ||
-    settings.bins.includes(path.addition)
+  const conflictsWithExistingAddition = (path) => (
+    settings.preserveOtherAdditions &&
+    path.addition !== null &&
+    !settings.benches.includes(path.addition) &&
+    !settings.bins.includes(path.addition)
   )
 
   // Iterate every tile in the map
@@ -20,19 +21,23 @@ export default function Add(settings) {
       const footpaths = elements.filter(element => element.type === "footpath")
 
       footpaths.forEach(path => {
-        if (canBuildAdditionOnPath(surface, path)) {
-          if (path?.slopeDirection === null) {
-            paths.unsloped.push({ path, x, y })
-          } else {
-            paths.sloped.push({ path, x, y })
-          }
+        if (!canBuildAdditionOnPath(surface, path)) {
+          return
+        }
+        if (conflictsWithExistingAddition(path)) {
+          return
+        }
+        if (path?.slopeDirection === null) {
+          paths.unsloped.push({ path, x, y })
+        } else {
+          paths.sloped.push({ path, x, y })
         }
       })
     }
   }
 
   // Build benches and bins on unsloped paths
-  paths.unsloped.filter(isBenchOrBin).forEach(({ path, x, y }) => {
+  paths.unsloped.forEach(({ path, x, y }) => {
     const { bench, bin } = settings
     const [addition, price] = findAdditionAndPrice(bench, bin, x, y)
     const cash = park.cash - price
@@ -46,7 +51,7 @@ export default function Add(settings) {
 
   // Build bins on sloped paths
 
-  paths.sloped.filter(isBenchOrBin).forEach(({ path, x, y }) => {
+  paths.sloped.forEach(({ path, x, y }) => {
     const cash = park.cash - PRICE_BIN
     const buildOnSlopedPath = (
       (

--- a/src/add.js
+++ b/src/add.js
@@ -6,11 +6,13 @@ const PRICE_BENCH = 50
 
 export default function Add(settings) {
   const paths = { unsloped: [], sloped: [] }
+  const benchIndexes = settings.benches.map(b => b.index)
+  const binIndexes = settings.bins.map(b => b.index)
   const conflictsWithExistingAddition = (path) => (
     settings.preserveOtherAdditions &&
     path.addition !== null &&
-    !settings.benches.includes(path.addition) &&
-    !settings.bins.includes(path.addition)
+    !benchIndexes.includes(path.addition) &&
+    !binIndexes.includes(path.addition)
   )
 
   // Iterate every tile in the map

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function main() {
       id: 1,
       classification: name,
       width: 300,
-      height: 100,
+      height: 115,
       widgets: Document(
         ...Dropdown(
           "Bench:",
@@ -36,6 +36,11 @@ function main() {
           "Build bins on all sloped footpaths",
           settings.buildBinsOnAllSlopedPaths,
           checked => { settings.buildBinsOnAllSlopedPaths = checked }
+        ),
+        Checkbox(
+          "Preserve other additions (e.g. lamps)",
+          settings.preserveOtherAdditions,
+          checked => { settings.preserveOtherAdditions = checked }
         ),
         Button("Add", () => {
           if (settings.configured) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,6 +1,7 @@
 const BENCH = "Benchwarmer.Bench"
 const BIN = "Benchwarmer.Bin"
 const BUILD = "Benchwarmer.BuildOnAllSlopedFootpaths"
+const PRESERVE = "Benchwarmer.PreserveOtherAdditions"
 
 export default class Settings {
   constructor(all) {
@@ -27,6 +28,10 @@ export default class Settings {
     return context.sharedStorage.get(BUILD, false)
   }
 
+  get preserveOtherAdditions() {
+    return context.sharedStorage.get(PRESERVE, true)
+  }
+
   set bench(number) {
     context.sharedStorage.set(BENCH, number)
   }
@@ -37,6 +42,10 @@ export default class Settings {
 
   set buildBinsOnAllSlopedPaths(value) {
     context.sharedStorage.set(BUILD, value)
+  }
+
+  set preserveOtherAdditions(value) {
+    context.sharedStorage.set(PRESERVE, value)
   }
 
   get configured() {

--- a/src/settings.js
+++ b/src/settings.js
@@ -18,8 +18,8 @@ export default class Settings {
   }
 
   get selections() {
-    const bench = context.sharedStorage.get(BENCH, 1)
-    const bin = context.sharedStorage.get(BIN, 1)
+    const bench = context.sharedStorage.get(BENCH, 0)
+    const bin = context.sharedStorage.get(BIN, 0)
 
     return { bench, bin }
   }


### PR DESCRIPTION
* Existing benches and bins are now correctly detected as such. Previously the plugin incorrectly identified benches and bins as "other additions" and didn't replace them when running the plugin.
* Option to not preserve other additions. I personally don't care about lamps and such and always want to have benches and bins on my paths.
* Select first bin/bench option in dropdown by default (regression from #7).