### PR TITLE
Fix benches/bins when switching scenarios

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,10 @@ import { Dropdown, Checkbox, Button, Document } from "./ui"
 const name = "Benchwarmer"
 
 function main() {
-  const additions = context.getAllObjects("footpath_addition")
-  const settings = new Settings()
-
   ui.registerMenuItem(name, () => {
-    settings.initializeAvailableAdditions(additions)
+    const additions = context.getAllObjects("footpath_addition")
+    const settings = new Settings(additions)
+
     const window = ui.openWindow({
       title: name,
       id: 1,

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,10 @@ const name = "Benchwarmer"
 
 function main() {
   const additions = context.getAllObjects("footpath_addition")
-  const settings = new Settings(additions)
+  const settings = new Settings()
 
   ui.registerMenuItem(name, () => {
+    settings.initializeAvailableAdditions(additions)
     const window = ui.openWindow({
       title: name,
       id: 1,

--- a/src/settings.js
+++ b/src/settings.js
@@ -3,7 +3,7 @@ const BIN = "Benchwarmer.Bin"
 const BUILD = "Benchwarmer.BuildOnAllSlopedFootpaths"
 
 export default class Settings {
-  constructor(all) {
+  initializeAvailableAdditions(all) {
     this.benches = all.filter(a => a.identifier.includes("bench"))
     this.bins = all.filter(a => a.identifier.includes("litter"))
   }

--- a/src/settings.js
+++ b/src/settings.js
@@ -3,7 +3,7 @@ const BIN = "Benchwarmer.Bin"
 const BUILD = "Benchwarmer.BuildOnAllSlopedFootpaths"
 
 export default class Settings {
-  initializeAvailableAdditions(all) {
+  constructor(all) {
     this.benches = all.filter(a => a.identifier.includes("bench"))
     this.bins = all.filter(a => a.identifier.includes("litter"))
   }


### PR DESCRIPTION
As discussed in #28: `benches`/`bins` gets corrupted when switching scenarios because the available additions depend on the scenario settings.
![image](https://user-images.githubusercontent.com/812086/94350299-d1d07900-0001-11eb-9c8e-538a99b29398.png)