### PR TITLE
feat: build additions as new paths are built

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 build
 types/openrct2.d.ts
+types/actions.d.ts

--- a/src/add.ts
+++ b/src/add.ts
@@ -31,7 +31,7 @@ export function Add(settings: Settings): Paths {
       ) as FootpathElement[];
 
       footpaths.forEach((path: FootpathElement) => {
-        if (canBuildAdditionOnPath(surface, path, settings)) {
+        if (canBuildAdditionOnPath(surface, path)) {
           if (path.isQueue) {
             paths.queues.push({ path, x, y });
           } else if (path?.slopeDirection === null) {
@@ -71,17 +71,15 @@ export function Add(settings: Settings): Paths {
   return paths;
 }
 
-function conflictsWithExistingAddition(
-  path: FootpathElement,
-  settings: Settings
-): boolean {
-  return path.addition !== null && settings.preserveOtherAdditions;
-}
-
 /**
  * Build the footpath addition on a footpath.
  */
-function ensureHasAddition(x: number, y: number, z: number, addition: number) {
+function ensureHasAddition(
+  x: number,
+  y: number,
+  z: number,
+  addition: number
+): void {
   context.executeAction(
     "footpathadditionplace",
     {
@@ -98,7 +96,12 @@ function ensureHasAddition(x: number, y: number, z: number, addition: number) {
   );
 }
 
-function findAddition(bench: number, bin: number, x: number, y: number) {
+export function findAddition(
+  bench: number,
+  bin: number,
+  x: number,
+  y: number
+): number {
   if (x % 2 === y % 2) {
     return bench;
   } else {
@@ -108,14 +111,9 @@ function findAddition(bench: number, bin: number, x: number, y: number) {
 
 function canBuildAdditionOnPath(
   surface: SurfaceElement,
-  path: FootpathElement,
-  settings: Settings
+  path: FootpathElement
 ) {
   if (!surface || !path) {
-    return false;
-  }
-
-  if (conflictsWithExistingAddition(path, settings)) {
     return false;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { version, author, license as licence } from "../package.json";
-import { Add } from "./add";
+import { Add, findAddition } from "./add";
 import { Settings } from "./settings";
 import { Dropdown, Checkbox, Button, Document } from "./ui";
 
@@ -55,6 +55,13 @@ function main() {
             settings.preserveOtherAdditions = checked;
           }
         ),
+        Checkbox(
+          "Add benches and bins as paths are placed",
+          settings.asYouGo,
+          (checked: boolean) => {
+            settings.asYouGo = checked;
+          }
+        ),
         Button("Build on All Paths", () => {
           if (settings.configured) {
             try {
@@ -66,6 +73,23 @@ function main() {
           window.close();
         })
       ),
+    });
+
+    context.subscribe("action.execute", ({ action, args, isClientOnly }) => {
+      if (action === "footpathplace" && settings.asYouGo && isClientOnly) {
+        const { x, y, z, slope } = args as FootpathPlaceArgs;
+        const addition = slope
+          ? settings.bin
+          : findAddition(settings.bench, settings.bin, x / 32, y / 32);
+
+        context.executeAction(
+          "footpathadditionplace",
+          { x, y, z, object: addition + 1 },
+          ({ errorTitle, errorMessage }) => {
+            if (errorMessage) throw new Error(`${errorTitle}: ${errorMessage}`);
+          }
+        );
+      }
     });
   });
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ const BIN = "Benchwarmer.Bin";
 const QUEUETV = "Benchwarmer.QueueTV";
 const BUILD = "Benchwarmer.BuildOnAllSlopedFootpaths";
 const PRESERVE = "Benchwarmer.PreserveOtherAdditions";
+const AS_YOU_GO = "Benchwarmer.BuildAsYouGo";
 
 type Selections = {
   bench: number;
@@ -75,5 +76,13 @@ export class Settings {
 
   get queueTVConfigured(): boolean {
     return this.queuetv !== null;
+  }
+
+  get asYouGo(): boolean {
+    return context.sharedStorage.get(AS_YOU_GO, false);
+  }
+
+  set asYouGo(value: boolean) {
+    context.sharedStorage.set(AS_YOU_GO, value);
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "**/node_modules/*"],
-  "include": ["types/openrct2.d.ts", "src/**/*"]
+  "include": ["types/*.d.ts", "src/**/*"]
 }

--- a/types/actions.d.ts
+++ b/types/actions.d.ts
@@ -1,0 +1,224 @@
+/*****************************************************************************
+ * Copyright (c) 2020-2022 Sadret
+ *
+ * The OpenRCT2 plug-in "Scenery Manager" is licensed
+ * under the GNU General Public License version 3.
+ *****************************************************************************/
+
+/*
+ * PLACE ACTIONS
+ */
+
+type PlaceAction =
+  | "bannerplace"
+  | "rideentranceexitplace"
+  | "footpathplace"
+  | "footpathadditionplace"
+  | "largesceneryplace"
+  | "smallsceneryplace"
+  | "trackplace"
+  | "wallplace";
+
+interface PlaceActionArgs {
+  readonly flags?: number;
+  readonly x: number;
+  readonly y: number;
+  readonly z: number; // except entrance
+}
+
+interface BannerPlaceArgs extends PlaceActionArgs {
+  readonly direction: number;
+  readonly object: number;
+  readonly primaryColour: number;
+}
+
+interface EntrancePlaceArgs extends PlaceActionArgs {
+  readonly direction: number;
+  readonly ride: number;
+  readonly station: number;
+  readonly isExit: boolean;
+}
+
+interface FootpathPlaceArgs extends PlaceActionArgs {
+  readonly direction: 0xff;
+  readonly object: number;
+  readonly railingsObject: number;
+  readonly slope: number;
+  readonly constructFlags: number;
+}
+
+interface FootpathAdditionPlaceArgs extends PlaceActionArgs {
+  readonly object: number;
+}
+
+interface LargeSceneryPlaceArgs extends PlaceActionArgs {
+  readonly direction: number;
+  readonly object: number;
+  readonly primaryColour: number;
+  readonly secondaryColour: number;
+}
+
+interface SmallSceneryPlaceArgs extends PlaceActionArgs {
+  readonly direction: number;
+  readonly object: number;
+  readonly quadrant: number;
+  readonly primaryColour: number;
+  readonly secondaryColour: number;
+}
+
+interface TrackPlaceArgs extends PlaceActionArgs {
+  readonly direction: number;
+  readonly ride: number;
+  readonly trackType: number;
+  readonly rideType: number;
+  readonly brakeSpeed: number;
+  readonly colour: number;
+  readonly seatRotation: number;
+  readonly trackPlaceFlags: number;
+  readonly isFromTrackDesign: boolean;
+}
+
+interface WallPlaceArgs extends PlaceActionArgs {
+  readonly object: number;
+  readonly edge: number; // = direction
+  readonly primaryColour: number;
+  readonly secondaryColour: number;
+  readonly tertiaryColour: number;
+}
+
+/*
+ * REMOVE ACTIONS
+ */
+
+type RemoveAction =
+  | "bannerremove"
+  | "rideentranceexitremove"
+  | "footpathremove"
+  | "footpathadditionremove"
+  | "largesceneryremove"
+  | "smallsceneryremove"
+  | "trackremove"
+  | "wallremove";
+
+interface RemoveActionArgs {
+  readonly flags?: number;
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+interface BannerRemoveArgs extends RemoveActionArgs {
+  readonly direction: number;
+}
+
+interface EntranceRemoveArgs extends RemoveActionArgs {
+  readonly ride: number;
+  readonly station: number;
+  readonly isExit: boolean;
+}
+
+interface FootpathRemoveArgs extends RemoveActionArgs {}
+
+interface FootpathAdditionRemoveArgs extends RemoveActionArgs {}
+
+interface LargeSceneryRemoveArgs extends RemoveActionArgs {
+  readonly direction: number;
+  readonly tileIndex: number;
+}
+
+interface SmallSceneryRemoveArgs extends RemoveActionArgs {
+  readonly object: number;
+  readonly quadrant: number;
+}
+
+interface TrackRemoveArgs extends RemoveActionArgs {
+  readonly direction: number;
+  readonly trackType: number;
+  readonly sequence: number;
+}
+
+interface WallRemoveArgs extends RemoveActionArgs {
+  readonly direction: number;
+}
+
+/*
+ * ACTION DATA
+ */
+
+interface ActionData<S extends ActionType, T extends object> {
+  readonly type: S;
+  readonly args: T;
+}
+
+/*
+ * PLACE ACTION DATA
+ */
+
+type BannerPlaceActionData = ActionData<"bannerplace", BannerPlaceArgs>;
+type EntrancePlaceActionData = ActionData<
+  "rideentranceexitplace",
+  EntrancePlaceArgs
+>;
+type FootpathPlaceActionData = ActionData<"footpathplace", FootpathPlaceArgs>;
+type FootpathAdditionPlaceActionData = ActionData<
+  "footpathadditionplace",
+  FootpathAdditionPlaceArgs
+>;
+type LargeSceneryPlaceActionData = ActionData<
+  "largesceneryplace",
+  LargeSceneryPlaceArgs
+>;
+type SmallSceneryPlaceActionData = ActionData<
+  "smallsceneryplace",
+  SmallSceneryPlaceArgs
+>;
+type TrackPlaceActionData = ActionData<"trackplace", TrackPlaceArgs>;
+type WallPlaceActionData = ActionData<"wallplace", WallPlaceArgs>;
+
+type PlaceActionData =
+  | BannerPlaceActionData
+  | EntrancePlaceActionData
+  | FootpathPlaceActionData
+  | FootpathAdditionPlaceActionData
+  | LargeSceneryPlaceActionData
+  | SmallSceneryPlaceActionData
+  | TrackPlaceActionData
+  | WallPlaceActionData;
+
+/*
+ * REMOVE ACTION DATA
+ */
+
+type BannerRemoveActionData = ActionData<"bannerremove", BannerRemoveArgs>;
+type EntranceRemoveActionData = ActionData<
+  "rideentranceexitremove",
+  EntranceRemoveArgs
+>;
+type FootpathRemoveActionData = ActionData<
+  "footpathremove",
+  FootpathRemoveArgs
+>;
+type FootpathAdditionRemoveActionData = ActionData<
+  "footpathadditionremove",
+  FootpathAdditionRemoveArgs
+>;
+type LargeSceneryRemoveActionData = ActionData<
+  "largesceneryremove",
+  LargeSceneryRemoveArgs
+>;
+type SmallSceneryRemoveActionData = ActionData<
+  "smallsceneryremove",
+  SmallSceneryRemoveArgs
+>;
+type TrackRemoveActionData = ActionData<"trackremove", TrackRemoveArgs>;
+type WallRemoveActionData = ActionData<"wallremove", WallRemoveArgs>;
+
+type RemoveActionData =
+  | BannerRemoveActionData
+  | EntranceRemoveActionData
+  | FootpathRemoveActionData
+  | FootpathAdditionRemoveActionData
+  | LargeSceneryRemoveActionData
+  | SmallSceneryRemoveActionData
+  | TrackRemoveActionData
+  | WallRemoveActionData;


### PR DESCRIPTION
Instead of clicking a button that overrides all empty paths, this mode allows a user to build path additions when new footpaths are built in the game. This gives finer-grained control over what will be added.

Resolves #14