### PR TITLE
Lamps and startup

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -5,7 +5,7 @@ import { mocked } from "ts-jest/utils";
 const sharedStorage = mocked(context.sharedStorage);
 
 describe("add", () => {
-  it("places benches and bins", () => {
+  it("places benches, bins, and lights", () => {
     expect.hasAssertions();
     sharedStorage.get.mockReturnValue(0);
 
@@ -24,8 +24,15 @@ describe("add", () => {
         legacyIdentifier: "litter",
         name: "litter bin",
       },
+      {
+        index: 2,
+        type: "footpath_addition",
+        identifier: "light",
+        legacyIdentifier: "light",
+        name: "light",
+      },
     ];
-    const [bench, bin] = all;
+    const [bench, bin, light] = all;
     const settings = new Settings(all);
     const { sloped, unsloped } = Add(settings);
     const paths = [...sloped, ...unsloped].map(({ path }) => path);
@@ -33,5 +40,6 @@ describe("add", () => {
     expect(paths).not.toHaveLength(0);
     expect(paths[1].addition).toStrictEqual(bench.index);
     expect(paths[2].addition).toStrictEqual(bin.index);
+    expect(paths[3].addition).toStrictEqual(light.index);
   });
 });

--- a/src/add.ts
+++ b/src/add.ts
@@ -44,10 +44,10 @@ export function Add(settings: Settings): Paths {
     }
   }
 
-  // Build benches and bins on unsloped paths
+  // Build benches, bins, and lights on unsloped paths
   paths.unsloped.forEach(({ path, x, y }) => {
-    const { bench, bin } = settings;
-    const addition = findAddition(bench, bin, x, y);
+    const { bench, bin, light } = settings;
+    const addition = findAddition(bench, bin, light, x, y);
 
     ensureHasAddition(x, y, path.baseZ, addition);
   });
@@ -99,13 +99,16 @@ function ensureHasAddition(
 export function findAddition(
   bench: number,
   bin: number,
+  light: number,
   x: number,
   y: number
 ): number {
-  if (x % 2 === y % 2) {
+  if (x % 3 === y % 3) {
     return bench;
-  } else {
+  } else if (Math.abs((x % 3) - (y % 3)) == 2) {
     return bin;
+  } else {
+    return light;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,14 @@ function main() {
             settings.queuetv = index;
           }
         ),
+        ...Dropdown(
+          "Light:",
+          settings.lights,
+          settings.selections.light,
+          (index: number) => {
+            settings.light = index;
+          }
+        ),
         Checkbox(
           "Build bins on all sloped footpaths",
           settings.buildBinsOnAllSlopedPaths,
@@ -56,7 +64,7 @@ function main() {
           }
         ),
         Checkbox(
-          "Add benches and bins as paths are placed",
+          "Add benches, bins, and lights as paths are placed",
           settings.asYouGo,
           (checked: boolean) => {
             settings.asYouGo = checked;

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -26,9 +26,16 @@ describe("settings", () => {
       legacyIdentifier: "qtv",
       name: "queue tv",
     },
+    {
+      index: 3,
+      type: "footpath_addition",
+      identifier: "lamp",
+      legacyIdentifier: "lamp",
+      name: "light",
+    },
   ];
 
-  it("returns bench and bin selections", () => {
+  it("returns bench, bin, and light selections", () => {
     expect.hasAssertions();
     sharedStorage.get.mockReturnValue(0);
 
@@ -37,6 +44,7 @@ describe("settings", () => {
     expect(settings.bench).toStrictEqual(0);
     expect(settings.bin).toStrictEqual(1);
     expect(settings.queuetv).toStrictEqual(2);
+    expect(settings.light).toStrictEqual(3);
     expect(settings.configured).toBe(true);
     expect(settings.queueTVConfigured).toBe(true);
   });
@@ -50,10 +58,12 @@ describe("settings", () => {
     settings.bench = 0;
     settings.bin = 0;
     settings.queuetv = 0;
+    settings.light = 0;
 
     expect(settings.bench).toStrictEqual(0);
     expect(settings.bin).toStrictEqual(1);
     expect(settings.queuetv).toStrictEqual(2);
+    expect(settings.light).toStrictEqual(3);
   });
 
   it("preserves additions", () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 const BENCH = "Benchwarmer.Bench";
 const BIN = "Benchwarmer.Bin";
 const QUEUETV = "Benchwarmer.QueueTV";
+const LIGHT = "Benchwarmer.Light";
 const BUILD = "Benchwarmer.BuildOnAllSlopedFootpaths";
 const PRESERVE = "Benchwarmer.PreserveOtherAdditions";
 const AS_YOU_GO = "Benchwarmer.BuildAsYouGo";
@@ -9,17 +10,20 @@ type Selections = {
   bench: number;
   bin: number;
   queuetv: number;
+  light: number;
 };
 
 export class Settings {
   benches: LoadedObject[];
   bins: LoadedObject[];
   queuetvs: LoadedObject[];
+  lights: LoadedObject[];
 
   constructor(all: LoadedObject[]) {
     this.benches = all.filter((a) => a.identifier.includes("bench"));
     this.bins = all.filter((a) => a.identifier.includes("litter"));
     this.queuetvs = all.filter((a) => a.identifier.includes("qtv"));
+    this.lights = all.filter((a) => a.identifier.includes("lamp"));
   }
 
   get bench(): number {
@@ -46,12 +50,21 @@ export class Settings {
     context.sharedStorage.set(QUEUETV, index);
   }
 
+  get light(): number {
+    return this.lights[this.selections.light]?.index;
+  }
+
+  set light(index: number) {
+    context.sharedStorage.set(LIGHT, index);
+  }
+
   get selections(): Selections {
     const bench = context.sharedStorage.get(BENCH, 0);
     const bin = context.sharedStorage.get(BIN, 0);
     const queuetv = context.sharedStorage.get(QUEUETV, 0);
+    const light = context.sharedStorage.get(LIGHT, 0);
 
-    return { bench, bin, queuetv };
+    return { bench, bin, queuetv, light };
   }
 
   get buildBinsOnAllSlopedPaths(): boolean {
@@ -71,7 +84,7 @@ export class Settings {
   }
 
   get configured(): boolean {
-    return this.bench !== null && this.bin !== null;
+    return this.bench !== null && this.bin !== null && this.light !== null;
   }
 
   get queueTVConfigured(): boolean {


### PR DESCRIPTION
- This fixes a bug where additions to new paths won't work, even if the box is checked, until you open the benchwarmer window for the first time. Now, after re-launching the game it will continue to add to new paths if the option was enabled.
- This adds lamps as a new addition (you can use the dropdown to select which style of lamp you prefer)