### PR TITLE
fix(types): resolve type checks after queue lines fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,9 +76,9 @@ function main() {
   });
   context.subscribe("action.execute", ({ action, args, isClientOnly }) => {
     if (action === "footpathplace" && settings.asYouGo && !isClientOnly) {
-      const { x, y, z, slope } = args as FootpathPlaceArgs;
+      const { x, y, z, slope, constructFlags } = args as FootpathPlaceArgs;
       let addition = settings.bin;
-      if (args.constructFlags & 1 == 1) {
+      if (constructFlags === 1) {
         addition = settings.queuetv;
       } else {
         addition = slope


### PR DESCRIPTION
Since #55 was fixed, there has been a type error in the compiler, preventing
builds and dependency updates. My fault for not noticing this, but this should
effectively be the same thing without the type issues since it's not relying
on the whole bitwise and/or thing to cast types in the runtime.
