### PR TITLE
feat: benches, bins, and queue TVs can be disabled

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -7,7 +7,8 @@ const sharedStorage = mocked(context.sharedStorage);
 describe("add", () => {
   it("places benches and bins", () => {
     expect.hasAssertions();
-    sharedStorage.get.mockReturnValue(0);
+    // mocked shared storage will return default value
+    sharedStorage.get.mockImplementation((_, defaultValue) => defaultValue);
 
     const all: LoadedObject[] = [
       {

--- a/src/add.ts
+++ b/src/add.ts
@@ -49,24 +49,30 @@ export function Add(settings: Settings): Paths {
     const { bench, bin } = settings;
     const addition = findAddition(bench, bin, x, y);
 
-    ensureHasAddition(x, y, path.baseZ, addition);
-  });
-
-  // Build bins on sloped paths
-  paths.sloped.forEach(({ path, x, y }) => {
-    const { buildBinsOnAllSlopedPaths } = settings;
-    const evenTile = x % 2 === y % 2;
-    const buildOnSlopedPath = buildBinsOnAllSlopedPaths || evenTile;
-
-    if (buildOnSlopedPath) {
-      ensureHasAddition(x, y, path.baseZ, settings.bin);
+    if (settings.isAdditionEnabled(addition)) {
+      ensureHasAddition(x, y, path.baseZ, addition);
     }
   });
 
+  // Build bins on sloped paths
+  if (settings.binEnabled) {
+    paths.sloped.forEach(({ path, x, y }) => {
+      const { buildBinsOnAllSlopedPaths } = settings;
+      const evenTile = x % 2 === y % 2;
+      const buildOnSlopedPath = buildBinsOnAllSlopedPaths || evenTile;
+
+      if (buildOnSlopedPath) {
+        ensureHasAddition(x, y, path.baseZ, settings.bin);
+      }
+    });
+  }
+
   // Build queue tvs on queue lines
-  paths.queues.forEach(({ path, x, y }) => {
-    ensureHasAddition(x, y, path.baseZ, settings.queuetv);
-  });
+  if (settings.queuetvEnabled) {
+    paths.queues.forEach(({ path, x, y }) => {
+      ensureHasAddition(x, y, path.baseZ, settings.queuetv);
+    });
+  }
 
   return paths;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ function main() {
       id: 1,
       classification: name,
       width: 300,
-      height: 160,
+      height: 205,
       widgets: Document(
         ...Dropdown(
           "Bench:",
@@ -22,6 +22,13 @@ function main() {
           settings.selections.bench,
           (index: number) => {
             settings.bench = index;
+          }
+        ),
+        Checkbox(
+          "Benches enabled",
+          settings.benchEnabled,
+          (checked: boolean) => {
+            settings.benchEnabled = checked;
           }
         ),
         ...Dropdown(
@@ -32,12 +39,22 @@ function main() {
             settings.bin = index;
           }
         ),
+        Checkbox("Bins enabled", settings.binEnabled, (checked: boolean) => {
+          settings.binEnabled = checked;
+        }),
         ...Dropdown(
           "Queue TV:",
           settings.queuetvs,
           settings.selections.queuetv,
           (index: number) => {
             settings.queuetv = index;
+          }
+        ),
+        Checkbox(
+          "Queue TVs enabled",
+          settings.queuetvEnabled,
+          (checked: boolean) => {
+            settings.queuetvEnabled = checked;
           }
         ),
         Checkbox(
@@ -85,13 +102,15 @@ function main() {
           ? settings.bin
           : findAddition(settings.bench, settings.bin, x / 32, y / 32);
       }
-      context.executeAction(
-        "footpathadditionplace",
-        { x, y, z, object: addition + 1 },
-        ({ errorTitle, errorMessage }) => {
-          if (errorMessage) throw new Error(`${errorTitle}: ${errorMessage}`);
-        }
-      );
+      if (settings.isAdditionEnabled(addition)) {
+        context.executeAction(
+          "footpathadditionplace",
+          { x, y, z, object: addition + 1 },
+          ({ errorTitle, errorMessage }) => {
+            if (errorMessage) throw new Error(`${errorTitle}: ${errorMessage}`);
+          }
+        );
+      }
     }
   });
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,9 @@
 const BENCH = "Benchwarmer.Bench";
+const BENCH_ENABLED = "Benchwarmer.BenchEnabled";
 const BIN = "Benchwarmer.Bin";
+const BIN_ENABLED = "Benchwarmer.BinEnabled";
 const QUEUETV = "Benchwarmer.QueueTV";
+const QUEUETV_ENABLED = "Benchwarmer.QueueTVEnabled";
 const BUILD = "Benchwarmer.BuildOnAllSlopedFootpaths";
 const PRESERVE = "Benchwarmer.PreserveOtherAdditions";
 const AS_YOU_GO = "Benchwarmer.BuildAsYouGo";
@@ -30,6 +33,14 @@ export class Settings {
     context.sharedStorage.set(BENCH, index);
   }
 
+  get benchEnabled(): boolean {
+    return context.sharedStorage.get(BENCH_ENABLED, true);
+  }
+
+  set benchEnabled(enabled: boolean) {
+    context.sharedStorage.set(BENCH_ENABLED, enabled);
+  }
+
   get bin(): number {
     return this.bins[this.selections.bin]?.index;
   }
@@ -38,12 +49,28 @@ export class Settings {
     context.sharedStorage.set(BIN, index);
   }
 
+  get binEnabled(): boolean {
+    return context.sharedStorage.get(BIN_ENABLED, true);
+  }
+
+  set binEnabled(enabled: boolean) {
+    context.sharedStorage.set(BIN_ENABLED, enabled);
+  }
+
   get queuetv(): number {
     return this.queuetvs[this.selections.queuetv]?.index;
   }
 
   set queuetv(index: number) {
     context.sharedStorage.set(QUEUETV, index);
+  }
+
+  get queuetvEnabled(): boolean {
+    return context.sharedStorage.get(QUEUETV_ENABLED, true);
+  }
+
+  set queuetvEnabled(enabled: boolean) {
+    context.sharedStorage.set(QUEUETV_ENABLED, enabled);
   }
 
   get selections(): Selections {
@@ -84,5 +111,15 @@ export class Settings {
 
   set asYouGo(value: boolean) {
     context.sharedStorage.set(AS_YOU_GO, value);
+  }
+
+  isAdditionEnabled(addition: number): boolean {
+    if (addition === this.bin) {
+      return this.binEnabled;
+    } else if (addition === this.bench) {
+      return this.benchEnabled;
+    } else {
+      return this.queuetvEnabled;
+    }
   }
 }


### PR DESCRIPTION
This feature allows choosing to not build one or more of benches, bins, and queue TVs, for instance if you wanted to build benches and bins on all paths but did not want to build queue TVs.