### PR TITLE
feat: add checkbox for controlling whether queue line tvs are built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.2](https://github.com/tubbo/openrct2-benchwarmer/compare/v1.0.1...v1.0.2) (2023-01-09)
+
+
+### Bug Fixes
+
+* **types:** resolve type checks after queue lines fix ([88b7f7e](https://github.com/tubbo/openrct2-benchwarmer/commit/88b7f7ed3db96e00bfcfe5f8d1439a3657dfd0a1)), closes [#55](https://github.com/tubbo/openrct2-benchwarmer/issues/55)
+
 ## [1.0.1](https://github.com/tubbo/openrct2-benchwarmer/compare/v1.0.0...v1.0.1) (2022-06-01)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrct2-benchwarmer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Add benches and trash cans to all of your paths with one click",
   "main": "build/benchwarmer.js",
   "scripts": {

--- a/src/add.ts
+++ b/src/add.ts
@@ -65,7 +65,10 @@ export function Add(settings: Settings): Paths {
 
   // Build queue tvs on queue lines
   paths.queues.forEach(({ path, x, y }) => {
-    ensureHasAddition(x, y, path.baseZ, settings.queuetv);
+    const { buildQueueTVs } = settings;
+    if (buildQueueTVs) {
+      ensureHasAddition(x, y, path.baseZ, settings.queuetv);
+    }
   });
 
   return paths;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,13 @@ function main() {
           }
         ),
         Checkbox(
+          "Build Queue TVs",
+          settings.buildQueueTVs,
+          (checked: boolean) => {
+            settings.buildQueueTVs = checked;
+          }
+        ),
+        Checkbox(
           "Build bins on all sloped footpaths",
           settings.buildBinsOnAllSlopedPaths,
           (checked: boolean) => {
@@ -85,13 +92,18 @@ function main() {
           ? settings.bin
           : findAddition(settings.bench, settings.bin, x / 32, y / 32);
       }
-      context.executeAction(
-        "footpathadditionplace",
-        { x, y, z, object: addition + 1 },
-        ({ errorTitle, errorMessage }) => {
-          if (errorMessage) throw new Error(`${errorTitle}: ${errorMessage}`);
-        }
-      );
+      if (
+        (addition == settings.queuetv && settings.buildQueueTVs) ||
+        addition != settings.queuetv
+      ) {
+        context.executeAction(
+          "footpathadditionplace",
+          { x, y, z, object: addition + 1 },
+          ({ errorTitle, errorMessage }) => {
+            if (errorMessage) throw new Error(`${errorTitle}: ${errorMessage}`);
+          }
+        );
+      }
     }
   });
 }

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -77,4 +77,15 @@ describe("settings", () => {
 
     expect(settings.preserveOtherAdditions).toBe(true);
   });
+
+  it("doesn't add queue tvs", () => {
+    expect.hasAssertions();
+    sharedStorage.get.mockReturnValue(false);
+
+    const settings = new Settings(additions);
+
+    settings.buildQueueTVs = false;
+
+    expect(settings.buildQueueTVs).toBe(false);
+  });
 });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ const BIN = "Benchwarmer.Bin";
 const QUEUETV = "Benchwarmer.QueueTV";
 const BUILD = "Benchwarmer.BuildOnAllSlopedFootpaths";
 const PRESERVE = "Benchwarmer.PreserveOtherAdditions";
+const BUILDTVS = "Benchwarmer.BuildQueueTVs";
 const AS_YOU_GO = "Benchwarmer.BuildAsYouGo";
 
 type Selections = {
@@ -52,6 +53,14 @@ export class Settings {
     const queuetv = context.sharedStorage.get(QUEUETV, 0);
 
     return { bench, bin, queuetv };
+  }
+
+  get buildQueueTVs(): boolean {
+    return context.sharedStorage.get(BUILDTVS, false);
+  }
+
+  set buildQueueTVs(value: boolean) {
+    context.sharedStorage.set(BUILDTVS, value);
   }
 
   get buildBinsOnAllSlopedPaths(): boolean {


### PR DESCRIPTION
A feature for excluding queue line TVs from the automatic behaviour is something I wanted, so I made a PR.
A few reasons I chose:

- They're expensive
- They don't necessarily provide value
- They are ugly

Since this is my first time touching both this language and this menuing system, I have a few things I think might make more sense to achieve this functionality;

- I don't know how the feature should be worded exactly
- It would be cleaner if the checkbox was tied to the TV dropdown as to indicate "the disabling of" (or a "unusable" TV fake-type)
- I'm slightly performance aware of checking for TV building status upon each "action.execute" -> "footpathplace" action; would determining that we're on a queue line earlier, and as such exiting sooner, be a more reasonable solution? 

Any feedback would be appreciated.