### PR TITLE
Fix Bin Number Change in OpenRCT2

### DIFF
--- a/add.ts
+++ b/add.ts
@@ -87,8 +87,7 @@ function ensureHasAddition(
       x: x * 32,
       y: y * 32,
       z,
-      // 0 means "no addition", so everything must be 1-indexed
-      object: addition + 1,
+      object: addition,
     },
     ({ errorTitle, errorMessage }) => {
       if (errorMessage) throw new Error(`${errorTitle}: ${errorMessage}`);

--- a/benchwarmer.ts
+++ b/benchwarmer.ts
@@ -87,7 +87,7 @@ function main() {
       }
       context.executeAction(
         "footpathadditionplace",
-        { x, y, z, object: addition + 1 },
+        { x, y, z, object: addition },
         ({ errorTitle, errorMessage }) => {
           if (errorMessage) throw new Error(`${errorTitle}: ${errorMessage}`);
         }

--- a/mocks/openrct2.js
+++ b/mocks/openrct2.js
@@ -6,7 +6,7 @@ global.context = {
     get: jest.fn(),
   },
   executeAction: (_action, args, callback) => {
-    tiles[args.x / 32][args.y / 32].elements[1].addition = args.object - 1;
+    tiles[args.x / 32][args.y / 32].elements[1].addition = args.object;
     callback({});
   },
 };


### PR DESCRIPTION
As a result of openrct2/openrct2#20177, we no longer need to mess with the
index number of the selected bin or bench. Adding the `+ 1` here was breaking
functionality on newer versions of OpenRCT2, and its removal has been confirmed
to work, so we're codifying it in the plugin now.

Shoutouts to @KyuuGryphon, @Soma91, and @JensMakerAdventures for finding the
fix for this one! Much obliged.

Fixes #76
